### PR TITLE
Query 'any' post type on settings page

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -318,14 +318,7 @@ if ( ! class_exists( 'Lity_Options' ) ) {
 			$query = new WP_Query(
 				array(
 					'posts_per_page' => -1,
-					'post_type'      => (array) apply_filters(
-						'lity_disabled_on_post_types',
-						array(
-							'post',
-							'page',
-							'product',
-						)
-					),
+					'post_type'      => 'any',
 				)
 			);
 
@@ -365,7 +358,7 @@ if ( ! class_exists( 'Lity_Options' ) ) {
 							?>
 
 							<option value="<?php echo esc_attr( $post_id ); ?>" <?php echo esc_attr( $selected ); ?>>
-								<?php echo empty( $post_title ) ? esc_html__( '- (no title)', 'lity' ) : esc_html( $post_title ); ?>
+								<?php echo empty( $post_title ) ? esc_html__( '(no title)', 'lity' ) : esc_html( $post_title ); ?>
 							</option>
 
 							<?php


### PR DESCRIPTION
- Remove the hardcoded post type values and set the WP_Query to 'any'.
  - `any` – Retrieves any type except revisions and types with ‘exclude_from_search’ set to true. [source](https://developer.wordpress.org/reference/classes/wp_query/#post-type-parameters)