### PR TITLE
Add pre-release workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,3 +1,4 @@
+---
 name: PHPUnit Tests
 
 on: push

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,27 @@
+---
+name: Pre-Release
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  pre-release:
+    name: Pre Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install yarn dependencies
+        run: yarn install
+
+      - name: Build the plugin
+        run: yarn build
+
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: latest
+          prerelease: true
+          title: Development Build
+          files: build/lity.zip

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ name: Pre-Release
 on:
   push:
     branches:
-      - "main"
+      - main
 
 jobs:
   pre-release:

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,25 @@
+---
+name: Tagged Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  tagged-release:
+    name: Tagged Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install yarn dependencies
+        run: yarn install
+
+      - name: Build the plugin
+        run: yarn build
+
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: build/lity.zip

--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,3 +1,4 @@
+---
 name: WPCS Check
 
 on: push

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
 # Lity
 
-A lightweight plugin to allow for all images to be opened in a lightbox.
+A lightweight WordPress plugin to allow for all images to be opened in a lightbox.
 
-Lightweight and highly configurable.
+- Lightweight and highly configurable.
+- Localized and ready for translations.
 
-
-### Installation
+## Installation
 - Download the .zip from this Github repository.
 - Head to your WordPress admin dashboard and navigate to 'Plugins > Add New'.
 - Upload the .zip file you downloaded in step 1.
 - Activate the plugin.
 - Head to 'Settings > Lity' to alter how the plugin works.
 - Enjoy :)
+
+## Credits
+
+This software uses the following open source packages:
+
+- [Lity](https://sorgalla.com/lity/)
+
+## License
+
+This plugin, like WordPress, is licensed under the GPL. Use it to make something cool, have fun, and share what you've learned with others.
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+---
+
+Copyright © 2022 Evan Herman. All Rights Reserved.
+
+[godaddy.com](https://www.evan-herman.com) &nbsp;&middot;&nbsp;
+GitHub [@EvanHerman](https://github.com/EvanHerman) &nbsp;&middot;&nbsp;
+Twitter [@EvanMHerman](https://twitter.com/EvanMHerman)


### PR DESCRIPTION
- Setup a pre-release workflow to build the plugin and attach it to a 'Development Build' [release](https://github.com/EvanHerman/lity/releases).
- Add a tagged release when any `v*` tags are committed.
- Update `readme.md`