### PR TITLE
Add lity_is_disabled filter

### DIFF
--- a/lity.php
+++ b/lity.php
@@ -110,6 +110,17 @@ if ( ! class_exists( 'Lity' ) ) {
 
 			}
 
+			/**
+			 * Allow users to disable lity via a filter.
+			 *
+			 * @var boolean
+			 */
+			if ( (bool) apply_filters( 'lity_is_disabled', false ) ) {
+
+				return;
+
+			}
+
 			$suffix = SCRIPT_DEBUG ? '' : '.min';
 
 			// Styles.


### PR DESCRIPTION
Using this filter allow users to disable lity on the front of site.

```php
add_filter( 'lity_is_disabled', '__return_true' );
```
or it can be used to disable on specific pages or all posts by ID or of a certain `post_type` etc.