### PR TITLE
Remove transient expiration

### DIFF
--- a/lity.php
+++ b/lity.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Lity' ) ) {
 
 			}
 
-			set_transient( 'lity_media', json_encode( $media ), 6 * MONTH_IN_SECONDS );
+			set_transient( 'lity_media', json_encode( $media ) );
 
 		}
 

--- a/lity.php
+++ b/lity.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Lity' ) ) {
 
 			}
 
-			set_transient( 'lity_media', json_encode( $media ), WEEK_IN_SECONDS );
+			set_transient( 'lity_media', json_encode( $media ), 6 * MONTH_IN_SECONDS );
 
 		}
 


### PR DESCRIPTION
This PR removes the `lity_media` transient expiration. That means this data will be cache indefinitely, until a new image is uploaded to the site or an existing image is updated. This is to prevent expensive queries on the database, and decrease load times.