### PR TITLE
Add WordPress deployment workflows

### DIFF
--- a/.github/workflows/update-wp-assets.yml
+++ b/.github/workflows/update-wp-assets.yml
@@ -1,0 +1,23 @@
+---
+name: Plugin asset/readme update
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '**'
+
+jobs:
+  master:
+    name: Update SVN Assets/Readme
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: WordPress.org plugin asset/readme update
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: wp-rest-api-controller
+          IGNORE_OTHER_FILES: true

--- a/.github/workflows/wp-deploy.yml
+++ b/.github/workflows/wp-deploy.yml
@@ -1,0 +1,20 @@
+---
+name: Deploy to WordPress.org
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  tag:
+    name: Deploy to WordPress.org
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: lity-responsive-lightboxes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Lity - Responsive Lightboxes
 	<a href="https://github.com/EvanHerman/Lity/releases/latest/">
-		<img src="https://img.shields.io/static/v1?lityVersion=&message=v1.0.0&label=&color=999&style=flat-square">
+		<img src="https://img.shields.io/static/v1?lityVersion=&message=v0.0.9&label=&color=999&style=flat-square">
 	</a>
 </h1>
 

--- a/lity.php
+++ b/lity.php
@@ -4,7 +4,7 @@
  * Description: Enables beautiful and responsive lightboxes on every image on your site.
  * Author: Evan Herman
  * Author URI: https://www.evan-herman.com
- * Version: 1.0.0
+ * Version: 0.0.9
  * Text Domain: lity
  * Domain Path: /languages
  * Tested up to: 6.0
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 }
 
-define( 'LITY_PLUGIN_VERSION', '1.0.0' );
+define( 'LITY_PLUGIN_VERSION', '0.0.9' );
 define( 'LITY_VERSION', '2.4.1' );
 define( 'LITY_SLIMSELECT_VERSION', '1.27.1' );
 define( 'LITY_TAGIFY_VERSION', '4.12.0' );

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "lity",
 	"title": "Lity",
 	"description": "Lity is a lightweight responsive lightbox plugin that allows for any and/or all images on your site open in a lightbox.",
-	"version": "1.0.0",
+	"version": "0.0.9",
 	"slimselect_version": "1.27.1",
 	"tagify_version": "4.12.0",
 	"tested_up_to": "6.0",
@@ -35,7 +35,7 @@
 		"postinstall": "composer install",
 		"update:action-scheduler": "git fetch subtree-action-scheduler trunk && git subtree pull --prefix includes/action-scheduler subtree-action-scheduler trunk --squash",
 		"version": "grunt version && yarn generate-pot && git add -A .",
-		"postversion": "git push && git push -f --tags"
+		"postversion": "git push && git push -f u--tags"
 	},
 	"watch": {
 		"min": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"postinstall": "composer install",
 		"update:action-scheduler": "git fetch subtree-action-scheduler trunk && git subtree pull --prefix includes/action-scheduler subtree-action-scheduler trunk --squash",
 		"version": "grunt version && yarn generate-pot && git add -A .",
-		"postversion": "git push && git push -f u--tags"
+		"postversion": "git push && git push -f --tags"
 	},
 	"watch": {
 		"min": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"postinstall": "composer install",
 		"update:action-scheduler": "git fetch subtree-action-scheduler trunk && git subtree pull --prefix includes/action-scheduler subtree-action-scheduler trunk --squash",
 		"version": "grunt version && yarn generate-pot && git add -A .",
-		"postversion": "git push && git push -f --tags"
+		"postversion": "git push && git push --tags"
 	},
 	"watch": {
 		"min": {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: responsive, lightbox, captions
 Requires at least: 5.0
 Tested up to: 6.0
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 0.0.9
 License: GPL-2.0
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
- Add deployment workflows to WordPress.org.
- Remove the -f on git tag commit.
- Revert to 0.0.9 again so we can re-run the tag release for `v1.0.0`.